### PR TITLE
Allow multiple hostnames

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Once you have that, creating your container is a snap:
       -v <path to configs>:/app/keystore \
       -e TRAKT_ID=<trakt_id> \
       -e TRAKT_SECRET=<trakt_secret> \
-      -e REDIRECT_URI=<your redirect uri (without /authorize)> \
+      -e ALLOWED_HOSTNAME=<your public hostname> \
       -p 8000:8000 \
       xanderstrike/goplaxt:latest
 

--- a/lib/trakt/main.go
+++ b/lib/trakt/main.go
@@ -15,13 +15,13 @@ import (
 	"github.com/xanderstrike/goplaxt/lib/store"
 )
 
-func AuthRequest(username, code, refreshToken, grantType string) map[string]interface{} {
+func AuthRequest(root, username, code, refreshToken, grantType string) map[string]interface{} {
 	values := map[string]string{
 		"code":          code,
 		"refresh_token": refreshToken,
 		"client_id":     os.Getenv("TRAKT_ID"),
 		"client_secret": os.Getenv("TRAKT_SECRET"),
-		"redirect_uri":  fmt.Sprintf("%s/authorize?username=%s", os.Getenv("REDIRECT_URI"), username),
+		"redirect_uri":  fmt.Sprintf("%s/authorize?username=%s", root, username),
 		"grant_type":    grantType,
 	}
 	jsonValue, _ := json.Marshal(values)

--- a/main.go
+++ b/main.go
@@ -148,5 +148,10 @@ func main() {
 		}
 		tmpl.Execute(w, data)
 	}).Methods("GET")
-	log.Fatal(http.ListenAndServe("0.0.0.0:8000", router))
+	listen := os.Getenv("LISTEN")
+	if listen == "" {
+		listen = "0.0.0.0:8000"
+	}
+	log.Print("Started on " + listen + "!")
+	log.Fatal(http.ListenAndServe(listen, router))
 }

--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ func authorize(w http.ResponseWriter, r *http.Request) {
 
 	user := store.NewUser(username, result["access_token"].(string), result["refresh_token"].(string))
 
-	url := fmt.Sprintf("%s/api?id=%s", os.Getenv("REDIRECT_URI"), user.ID)
+	url := fmt.Sprintf("%s/api?id=%s", SelfRoot(r), user.ID)
 
 	log.Print(fmt.Sprintf("Authorized as %s", user.ID))
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"github.com/gorilla/handlers"
+
+	"github.com/stretchr/testify/assert"
+
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSelfRoot(t *testing.T) {
+	var (
+		r   *http.Request
+		err error
+	)
+
+	// Test Default
+	r, err = http.NewRequest("GET", "/authorize", nil)
+	r.Host = "foo.bar"
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, "http://foo.bar", SelfRoot(r))
+
+	// Test Manual forwarded proto
+	r, err = http.NewRequest("GET", "/validate", nil)
+	r.Host = "foo.bar"
+	r.Header.Set("X-Forwarded-Proto", "https")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, "https://foo.bar", SelfRoot(r))
+
+	// Test ProxyHeader handler
+	rr := httptest.NewRecorder()
+	r, err = http.NewRequest("GET", "/validate", nil)
+	r.Header.Set("X-Forwarded-Host", "foo.bar")
+	r.Header.Set("X-Forwarded-Proto", "https")
+	handlers.ProxyHeaders(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})).ServeHTTP(rr, r)
+	assert.Equal(t, "https://foo.bar", SelfRoot(r))
+}

--- a/static/index.html
+++ b/static/index.html
@@ -103,9 +103,7 @@
     crossorigin="anonymous"></script>
 
     <script>
-      var full = location.protocol+'//'+location.hostname+(location.port ? ':'+location.port: '');
-      console.log(full);
-      var authorization_link = "https://trakt.tv/oauth/authorize?client_id={{.ClientID}}&redirect_uri=" + full + "/authorize%3fusername=USERNAME&response_type=code";
+      var authorization_link = "https://trakt.tv/oauth/authorize?client_id={{.ClientID}}&redirect_uri={{.SelfRoot}}/authorize%3fusername=USERNAME&response_type=code";
 
       $('.js-authorize').click(function() {
         var username = $('.js-username').val().toLowerCase();


### PR DESCRIPTION
I have an inhouse k8s cluster I use for deploying random apps. I have an internal hostname I use for testing that everything works right. The existing codebase didn't allow me to support my internal and external hostname. 

I don't really think it is beneficial to anyone but me, but I wanted the practice writing go code, and writing tests.