### PR TITLE
use the goplaxt namespace for all redis items so there's absolutely no chance of collisions

### DIFF
--- a/lib/store/redis.go
+++ b/lib/store/redis.go
@@ -48,12 +48,12 @@ func (s RedisStore) WriteUser(user User) {
 	data["access"] = user.AccessToken
 	data["refresh"] = user.RefreshToken
 	data["updated"] = user.Updated.Format("01-02-2006")
-	s.client.HMSet("user:"+user.ID, data)
+	s.client.HMSet("goplaxt:user:"+user.ID, data)
 }
 
 // GetUser will load a user from redis
 func (s RedisStore) GetUser(id string) *User {
-	data, err := s.client.HGetAll("user:" + id).Result()
+	data, err := s.client.HGetAll("goplaxt:user:" + id).Result()
 	// FIXME - return err
 	if err != nil {
 		panic(err)

--- a/lib/store/redis_test.go
+++ b/lib/store/redis_test.go
@@ -18,10 +18,10 @@ func TestLoadingUser(t *testing.T) {
 
 	store := NewRedisStore(NewRedisClient(s.Addr(), ""))
 
-	s.HSet("user:id123", "username", "halkeye")
-	s.HSet("user:id123", "access", "access123")
-	s.HSet("user:id123", "refresh", "refresh123")
-	s.HSet("user:id123", "updated", "02-25-2019")
+	s.HSet("goplaxt:user:id123", "username", "halkeye")
+	s.HSet("goplaxt:user:id123", "access", "access123")
+	s.HSet("goplaxt:user:id123", "refresh", "refresh123")
+	s.HSet("goplaxt:user:id123", "updated", "02-25-2019")
 
 	expected, err := json.Marshal(&User{
 		ID:           "id123",
@@ -54,10 +54,10 @@ func TestSavingUser(t *testing.T) {
 
 	originalUser.save()
 
-	assert.Equal(t, s.HGet("user:id123", "username"), "halkeye")
-	assert.Equal(t, s.HGet("user:id123", "access"), "access123")
-	assert.Equal(t, s.HGet("user:id123", "refresh"), "refresh123")
-	assert.Equal(t, s.HGet("user:id123", "updated"), "02-25-2019")
+	assert.Equal(t, s.HGet("goplaxt:user:id123", "username"), "halkeye")
+	assert.Equal(t, s.HGet("goplaxt:user:id123", "access"), "access123")
+	assert.Equal(t, s.HGet("goplaxt:user:id123", "refresh"), "refresh123")
+	assert.Equal(t, s.HGet("goplaxt:user:id123", "updated"), "02-25-2019")
 
 	expected, err := json.Marshal(originalUser)
 	actual, err := json.Marshal(store.GetUser("id123"))


### PR DESCRIPTION
I figured user: is pretty generic, so changed it to goplaxt:user: