### PR TITLE
no matter what allow healthcheck url to be hit

### DIFF
--- a/main.go
+++ b/main.go
@@ -112,6 +112,10 @@ func allowedHostsHandler(allowedHostnames string) func(http.Handler) http.Handle
 	log.Println("Allowed Hostnames:", allowedHosts)
 	return func(h http.Handler) http.Handler {
 		fn := func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.EscapedPath() == "/healthcheck" {
+				h.ServeHTTP(w, r)
+				return
+			}
 			isAllowedHost := false
 			lcHost := strings.ToLower(r.Host)
 			for _, value := range allowedHosts {

--- a/main_test.go
+++ b/main_test.go
@@ -87,6 +87,21 @@ func TestAllowedHostsHandler_mismatch_hostname(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, rr.Result().StatusCode)
 }
 
+func TestAllowedHostsHandler_alwaysAllowHealthcheck(t *testing.T) {
+	storage = &MockSuccessStore{}
+	f := allowedHostsHandler("unknown.host")
+
+	rr := httptest.NewRecorder()
+	r, err := http.NewRequest("GET", "/healthcheck", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.Host = "known.host"
+
+	f(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})).ServeHTTP(rr, r)
+	assert.Equal(t, http.StatusOK, rr.Result().StatusCode)
+}
+
 type MockSuccessStore struct{}
 
 func (s MockSuccessStore) Ping() error                   { return nil }


### PR DESCRIPTION
k8s http check uses localhost
Could arguably just add it to allowed hosts
Your call