### PR TITLE
Make intro accessible to new-comers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Plaxt
 
+Plex provides webhook integration for all Plex Pass subscribers, and users of their servers. A webhook is a request that the Plex application sends to third party services when a user takes an action, such as watching a movie or episode.
+
+You can ask Plex to send these webhooks to this tool, which will then log those plays in your Trakt account.
+
 This is a full rewrite of my somewhat popular previous iteration. This time it's written in Go
 and deployable with Docker so I can run it on my own infrastructure instead of Heroku.
 


### PR DESCRIPTION
Currently the readme assumes familiarity with (an unlinked) previous non-Go iteration.

This commit makes it a bit more accessible to new-comers, such as myself. (Copy taken from the hosted instance linked.)

It's still not clear to me whether Plaxt syncs in both directions, or Plex -> Trakt only? It reads like the latter, but I read a prominent Plex community developer claiming on Reddit that Trakt -> Plex without a plugin was a solved problem, and in Plaxt lay the solution. I think the readme should make it clearer either way, but I'm not presently in a position to do that.