### PR TITLE
Multistage Dockerfiles for amd64 and arm32v7

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.circleci/*
+.dockerignore
+Dockerfile*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,0 @@
-FROM iron/go
-WORKDIR /app
-RUN mkdir /app/keystore
-VOLUME /app/keystore/
-ADD goplaxt-docker /app/
-COPY static/ /app/static/
-EXPOSE 8000
-ENTRYPOINT ["./goplaxt-docker"]
-

--- a/Dockerfile-amd64
+++ b/Dockerfile-amd64
@@ -1,0 +1,16 @@
+FROM golang:alpine as builder
+WORKDIR $GOPATH/src/github.com/xanderstrike/goplaxt/ 
+COPY . .
+RUN mkdir /out
+RUN mkdir /out/keystore
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /out/goplaxt-docker
+
+FROM scratch
+LABEL maintainer="xanderstrike@gmail.com"
+WORKDIR /app
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=builder /out .
+COPY static ./static
+VOLUME /app/keystore/
+EXPOSE 8000
+ENTRYPOINT ["/app/goplaxt-docker"]

--- a/Dockerfile-arm7
+++ b/Dockerfile-arm7
@@ -1,0 +1,16 @@
+FROM golang:alpine as builder
+WORKDIR $GOPATH/src/github.com/xanderstrike/goplaxt/ 
+COPY . .
+RUN mkdir /out
+RUN mkdir /out/keystore
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=7 go build -o /out/goplaxt-docker
+
+FROM scratch
+LABEL maintainer="xanderstrike@gmail.com"
+WORKDIR /app
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=builder /out .
+COPY static ./static
+VOLUME /app/keystore/
+EXPOSE 8000
+ENTRYPOINT ["/app/goplaxt-docker"]


### PR DESCRIPTION
I've created two separate Dockerfiles since that's the simplest way I found to integrate the automated dockerhub builds.

You can find both tags at:
https://hub.docker.com/r/pabloromeo/goplaxt

latest => amd64
latest-arm32v7 => the build compatible with Raspberry Pi

Technically they can both be unified into a single Dockerfile with arguments, but I believe that requires the use of build hooks in order to get Dockerhub's automated builds to work.
Multiarch images seems to require QEMU to run on Dockerhub so that may require some additional work. But this could be a good start to offer a RPI compatible image.

Disclaimer: I'm currently only running the RPI image with proper Traktv integration so you might want to give the other image a test as well.