### PR TITLE
Swap out healthcheck support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,9 @@ module github.com/xanderstrike/goplaxt
 go 1.12
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.3.3
 	github.com/alicebob/miniredis/v2 v2.8.0
+	github.com/etherlabsio/healthcheck v0.0.0-20190516102650-2b759a75f4be
 	github.com/go-redis/redis v0.0.0-20190305141034-b665d8fcf239
 	github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c
 	github.com/gorilla/handlers v0.0.0-20190227193432-ac6d24f88de4

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/DATA-DOG/go-sqlmock v1.3.3 h1:CWUqKXe0s8A2z6qCgkP4Kru7wC11YoAnoupUKFDnH08=
+github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/alicebob/gopher-json v0.0.0-20180125190556-5a6b3ba71ee6 h1:45bxf7AZMwWcqkLzDAQugVEwedisr5nRJ1r+7LYnv0U=
 github.com/alicebob/gopher-json v0.0.0-20180125190556-5a6b3ba71ee6/go.mod h1:SGnFV6hVsYE877CKEZ6tDNTjaSXYUk6QqoIK6PrAtcc=
 github.com/alicebob/miniredis/v2 v2.8.0 h1:D2PcdeNYhveIx1zwrymjHKlm0wS8CO6U/byxwkwgnco=
@@ -7,6 +9,8 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/etherlabsio/healthcheck v0.0.0-20190516102650-2b759a75f4be h1:wATB6UPE3m0x3vfnRuIRfCvrfmRjo1CaHtYxY4yf1IY=
+github.com/etherlabsio/healthcheck v0.0.0-20190516102650-2b759a75f4be/go.mod h1:ZMSmptAGNIg5UAxsJzmw5DMW6uQvxr/hvCklNwtFz1k=
 github.com/go-redis/redis v0.0.0-20190305141034-b665d8fcf239 h1:t0CxOdtLscoWjfxYfrkNKUstzoK3bDQkGYXcVu3/G7A=
 github.com/go-redis/redis v0.0.0-20190305141034-b665d8fcf239/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
 github.com/gomodule/redigo v2.0.0+incompatible h1:K/R+8tc58AaqLkqG2Ol3Qk+DR/TlNuhuh457pBFPtt0=

--- a/lib/store/disk.go
+++ b/lib/store/disk.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -17,7 +18,7 @@ func NewDiskStore() *DiskStore {
 }
 
 // Ping will check if the connection works right
-func (s DiskStore) Ping() error {
+func (s DiskStore) Ping(ctx context.Context) error {
 	// TODO not sure what can fail here
 	return nil
 }

--- a/lib/store/main.go
+++ b/lib/store/main.go
@@ -1,12 +1,14 @@
 package store
 
-import ()
+import (
+	"context"
+)
 
 // Store is the interface for All the store types
 type Store interface {
 	WriteUser(user User)
 	GetUser(id string) *User
-	Ping() error
+	Ping(ctx context.Context) error
 }
 
 // Utils

--- a/lib/store/redis.go
+++ b/lib/store/redis.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"strings"
 	"time"
 
@@ -36,8 +37,8 @@ func NewRedisStore(client redis.Client) RedisStore {
 }
 
 // Ping will check if the connection works right
-func (s RedisStore) Ping() error {
-	_, err := s.client.Ping().Result()
+func (s RedisStore) Ping(ctx context.Context) error {
+	_, err := s.client.WithContext(ctx).Ping().Result()
 	return err
 }
 

--- a/lib/store/redis_test.go
+++ b/lib/store/redis_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -73,5 +74,5 @@ func TestPing(t *testing.T) {
 	defer s.Close()
 
 	store := NewRedisStore(NewRedisClient(s.Addr(), ""))
-	assert.Equal(t, store.Ping(), nil)
+	assert.Equal(t, store.Ping(context.TODO()), nil)
 }

--- a/main.go
+++ b/main.go
@@ -143,7 +143,7 @@ func healthcheckHandler() http.Handler {
 	return healthcheck.Handler(
 		healthcheck.WithTimeout(5*time.Second),
 		healthcheck.WithChecker("storage", healthcheck.CheckerFunc(func(ctx context.Context) error {
-			return storage.Ping()
+			return storage.Ping(ctx)
 		})),
 	)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -124,13 +124,13 @@ func TestHealthcheck(t *testing.T) {
 
 	storage = &MockSuccessStore{}
 	rr = httptest.NewRecorder()
-	http.HandlerFunc(healthcheck).ServeHTTP(rr, r)
+	http.Handler(healthcheckHandler()).ServeHTTP(rr, r)
 	assert.Equal(t, http.StatusOK, rr.Result().StatusCode)
-	assert.Equal(t, "{\"Storage\":\"\"}\n", rr.Body.String())
+	assert.Equal(t, "{\"status\":\"OK\"}\n", rr.Body.String())
 
 	storage = &MockFailStore{}
 	rr = httptest.NewRecorder()
-	http.HandlerFunc(healthcheck).ServeHTTP(rr, r)
-	assert.Equal(t, http.StatusInternalServerError, rr.Result().StatusCode)
-	assert.Equal(t, "{\"Storage\":\"OH NO\"}\n", rr.Body.String())
+	http.Handler(healthcheckHandler()).ServeHTTP(rr, r)
+	assert.Equal(t, http.StatusServiceUnavailable, rr.Result().StatusCode)
+	assert.Equal(t, "{\"status\":\"Service Unavailable\",\"errors\":{\"storage\":\"OH NO\"}}\n", rr.Body.String())
 }

--- a/main_test.go
+++ b/main_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/gorilla/handlers"
 	"github.com/stretchr/testify/assert"
 
+	"context"
 	"errors"
 
 	"net/http"
@@ -104,15 +105,15 @@ func TestAllowedHostsHandler_alwaysAllowHealthcheck(t *testing.T) {
 
 type MockSuccessStore struct{}
 
-func (s MockSuccessStore) Ping() error                   { return nil }
-func (s MockSuccessStore) WriteUser(user store.User)     {}
-func (s MockSuccessStore) GetUser(id string) *store.User { return nil }
+func (s MockSuccessStore) Ping(ctx context.Context) error { return nil }
+func (s MockSuccessStore) WriteUser(user store.User)      {}
+func (s MockSuccessStore) GetUser(id string) *store.User  { return nil }
 
 type MockFailStore struct{}
 
-func (s MockFailStore) Ping() error                   { return errors.New("OH NO") }
-func (s MockFailStore) WriteUser(user store.User)     { panic(errors.New("OH NO")) }
-func (s MockFailStore) GetUser(id string) *store.User { panic(errors.New("OH NO")) }
+func (s MockFailStore) Ping(ctx context.Context) error { return errors.New("OH NO") }
+func (s MockFailStore) WriteUser(user store.User)      { panic(errors.New("OH NO")) }
+func (s MockFailStore) GetUser(id string) *store.User  { panic(errors.New("OH NO")) }
 
 func TestHealthcheck(t *testing.T) {
 	var rr *httptest.ResponseRecorder


### PR DESCRIPTION
I found this cool healthcheck library, it does a lot of the work for you, including timeouts and better reporting

Failure:
```
{"status":"Service Unavailable","errors":{"storage":"dial tcp [::1]:5432: connect: connection refused"}}
```