### PR TITLE
Pin to a specific version of alpine, for reproducability

### DIFF
--- a/Dockerfile-amd64
+++ b/Dockerfile-amd64
@@ -1,5 +1,5 @@
-FROM golang:alpine as builder
-WORKDIR $GOPATH/src/github.com/xanderstrike/goplaxt/ 
+FROM golang:1.12.7-alpine as builder
+WORKDIR $GOPATH/src/github.com/xanderstrike/goplaxt/
 RUN apk add --no-cache git
 COPY . .
 RUN mkdir /out

--- a/Dockerfile-arm7
+++ b/Dockerfile-arm7
@@ -1,4 +1,4 @@
-FROM golang:alpine as builder
+FROM golang:1.12.7-alpine as builder
 WORKDIR $GOPATH/src/github.com/xanderstrike/goplaxt/ 
 RUN apk add --no-cache git
 COPY . .


### PR DESCRIPTION
Problem:

Docker build was complaining that i needed 1.12
I realized "golang:alpine" on my machine was outdated.
Pin the version to a specific one, then enable dependabot (github) to update it with a PR, so you have safe guaranteed builds.