### PR TITLE
Add support of TheMovieDB for TV Shows

### DIFF
--- a/lib/trakt/main.go
+++ b/lib/trakt/main.go
@@ -79,12 +79,22 @@ func HandleMovie(pr plexhooks.PlexResponse, accessToken string) {
 }
 
 func findEpisode(pr plexhooks.PlexResponse) Episode {
-	re := regexp.MustCompile("thetvdb://(\\d*)/(\\d*)/(\\d*)")
-	showID := re.FindStringSubmatch(pr.Metadata.Guid)
+	var traktService = "tvdb"
+	var showID []string
 
-	log.Print(fmt.Sprintf("Finding show for %s %s %s", showID[1], showID[2], showID[3]))
+	re := regexp.MustCompile("tvdb://(\\d*)/(\\d*)/(\\d*)")
+	showID = re.FindStringSubmatch(pr.Metadata.Guid)
 
-	url := fmt.Sprintf("https://api.trakt.tv/search/tvdb/%s?type=show", showID[1])
+	// If Plaxt can't find with TVDB, retry with TheMovieDB
+	if showID == nil {
+		re := regexp.MustCompile("themoviedb://(\\d*)/(\\d*)/(\\d*)")
+		showID = re.FindStringSubmatch(pr.Metadata.Guid)
+		traktService = "tmdb"
+	}
+
+	url := fmt.Sprintf("https://api.trakt.tv/search/%s/%s?type=show", traktService, showID[1])
+
+	log.Print(fmt.Sprintf("Finding show for %s %s %s using %s", showID[1], showID[2], showID[3], traktService))
 
 	resp_body := makeRequest(url)
 

--- a/lib/trakt/structs.go
+++ b/lib/trakt/structs.go
@@ -1,5 +1,6 @@
 package trakt
 
+// Ids represent the IDs representing a media item accross the metadata providers
 type Ids struct {
 	Trakt  int    `json:"trakt"`
 	Tvdb   int    `json:"tvdb"`
@@ -8,14 +9,17 @@ type Ids struct {
 	Tvrage int    `json:"tvrage"`
 }
 
+// Show represent a show's IDs
 type Show struct {
 	Ids Ids
 }
 
+// ShowInfo represent a show
 type ShowInfo struct {
 	Show Show
 }
 
+// Episode represent an episode
 type Episode struct {
 	Season int    `json:"season"`
 	Number int    `json:"number"`
@@ -23,26 +27,31 @@ type Episode struct {
 	Ids    Ids    `json:"ids"`
 }
 
+// Season represent a season
 type Season struct {
 	Number   int
 	Episodes []Episode
 }
 
+// Movie represent a movie
 type Movie struct {
 	Title string `json:"title"`
 	Year  int    `json:"year"`
 	Ids   Ids    `json:"ids"`
 }
 
+// MovieSearchResult represent a search result for a movie
 type MovieSearchResult struct {
 	Movie Movie
 }
 
+// ShowScrobbleBody represent the scrobbling status for a show
 type ShowScrobbleBody struct {
 	Episode  Episode `json:"episode"`
 	Progress int     `json:"progress"`
 }
 
+// MovieScrobbleBody represent the scrobbling status for a movie
 type MovieScrobbleBody struct {
 	Movie    Movie `json:"movie"`
 	Progress int   `json:"progress"`


### PR DESCRIPTION
Hi! 

This PR add support for TheMovieDB agent (for TV Shows) in addition to TVDB.
It's automatically trying TMDB if TVDB fails, so there is no need for special configuration.

EDIT: I added another commit to fix some Go warnings about variable naming and structure exports