### PR TITLE
Add support for new Plex TV agent

### DIFF
--- a/lib/trakt/structs.go
+++ b/lib/trakt/structs.go
@@ -11,12 +11,15 @@ type Ids struct {
 
 // Show represent a show's IDs
 type Show struct {
-	Ids Ids
+	Title string `json:"title"`
+	Year  int    `json:"year"`
+	Ids   Ids
 }
 
 // ShowInfo represent a show
 type ShowInfo struct {
-	Show Show
+	Show    Show
+	Episode Episode
 }
 
 // Episode represent an episode


### PR DESCRIPTION
Hi! Plex recently released a new Plex TV agent, it's still in beta but should hit the stable channel pretty soon. This PR add support for that new Plex TV agent.

Main difference is that it is using episode IDs instead of show IDs. It is still checking if the item is a TVDB or TheMovieDB item first, and if it is not, then it fallback to the new Plex TV agent. 