### PR TITLE
Hama improvement

### DIFF
--- a/lib/trakt/main.go
+++ b/lib/trakt/main.go
@@ -86,7 +86,7 @@ func findEpisode(pr plexhooks.PlexResponse) Episode {
 	var traktService = "tvdb"
 	var showID []string
 
-	re := regexp.MustCompile("tvdb://(\\d*)/(\\d*)/(\\d*)")
+	re := regexp.MustCompile("tvdb(?:://|[2-5]?-)(\\d*)/(\\d*)/(\\d*)")
 	showID = re.FindStringSubmatch(pr.Metadata.Guid)
 
 	// Retry with TheMovieDB
@@ -120,13 +120,6 @@ func findEpisode(pr plexhooks.PlexResponse) Episode {
 		return showInfo[0].Episode
 	}
 	
-	// Retry with Hama in TVDB mode
-	if showID == nil {
-		re := regexp.MustCompile("com.plexapp.agents.hama://tvdb-(\\d*)/(\\d*)/(\\d*)")
-		showID = re.FindStringSubmatch(pr.Metadata.Guid)
-		traktService = "tvdb"
-	}
-
 	url := fmt.Sprintf("https://api.trakt.tv/search/%s/%s?type=show", traktService, showID[1])
 
 	log.Print(fmt.Sprintf("Finding show for %s %s %s using %s", showID[1], showID[2], showID[3], traktService))


### PR DESCRIPTION
Improve on #60 by shaving a check and supporting HAMA's* [additional TVDB mapping modes](https://github.com/ZeroQI/Absolute-Series-Scanner#forcing-the-movieseries-id)

*= ASS's actually, but HAMA will inherit it

 - [x] Tested and working
---
### Entry GUIDs:
```xml
<Video ... guid="com.plexapp.agents.hama://tvdb-371437/2/3?lang=en" ... >
<Video ... guid="com.plexapp.agents.hama://tvdb2-79895/8/1?lang=en" ... >
<Video ... guid="com.plexapp.agents.thetvdb://275274/5/9?lang=en" ... >
```
### Log Output:
```log
plaxt     | 2021/09/18 23:38:22 Webhook call for xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
plaxt     | 2021/09/18 23:38:22 Finding show for 371437 2 3 using tvdb
plaxt     | 2021/09/18 23:38:22 Event logged
plaxt     | 2021/09/18 23:38:28 Webhook call for xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
plaxt     | 2021/09/18 23:38:28 Finding show for 371437 2 3 using tvdb
plaxt     | 2021/09/18 23:38:28 Event logged
plaxt     | 2021/09/18 23:38:33 Webhook call for xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
plaxt     | 2021/09/18 23:38:33 Finding show for 79895 8 1 using tvdb
plaxt     | 2021/09/18 23:38:33 Event logged
plaxt     | 2021/09/18 23:38:33 Webhook call for xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
plaxt     | 2021/09/18 23:38:33 Finding show for 79895 8 1 using tvdb
plaxt     | 2021/09/18 23:38:33 Event logged
plaxt     | 2021/09/18 23:38:39 Webhook call for xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
plaxt     | 2021/09/18 23:38:39 Finding show for 79895 8 1 using tvdb
plaxt     | 2021/09/18 23:38:39 Event logged
plaxt     | 2021/09/18 23:40:11 Webhook call for xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
plaxt     | 2021/09/18 23:40:11 Finding show for 275274 5 9 using tvdb
plaxt     | 2021/09/18 23:40:11 Event logged
plaxt     | 2021/09/18 23:40:11 Webhook call for xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
plaxt     | 2021/09/18 23:40:11 Finding show for 275274 5 9 using tvdb
plaxt     | 2021/09/18 23:40:11 Event logged
```
