### PR TITLE
Add option to read Trakt config values from files

### DIFF
--- a/lib/config/main.go
+++ b/lib/config/main.go
@@ -1,0 +1,18 @@
+package config
+
+import (
+	"io/ioutil"
+	"os"
+	"strings"
+)
+
+var TraktClientId string = getConfig("TRAKT_ID")
+var TraktClientSecret string = getConfig("TRAKT_SECRET")
+
+func getConfig(name string) string {
+	if os.Getenv(name) != "" {
+		return os.Getenv(name)
+	}
+
+	return ""
+}

--- a/lib/config/main.go
+++ b/lib/config/main.go
@@ -12,6 +12,14 @@ var TraktClientSecret string = getConfig("TRAKT_SECRET")
 func getConfig(name string) string {
 	if os.Getenv(name) != "" {
 		return os.Getenv(name)
+	} else if os.Getenv(name+"_FILE") != "" {
+		file, err := ioutil.ReadFile(os.Getenv(name + "_FILE"))
+
+		if err != nil {
+			panic(err)
+		}
+
+		return strings.TrimSpace(string(file))
 	}
 
 	return ""

--- a/lib/trakt/main.go
+++ b/lib/trakt/main.go
@@ -8,9 +8,9 @@ import (
 	"log"
 	"net/http"
 	"net/url"
-	"os"
 	"regexp"
 
+	"github.com/xanderstrike/goplaxt/lib/config"
 	"github.com/xanderstrike/goplaxt/lib/store"
 	"github.com/xanderstrike/plexhooks"
 )
@@ -20,8 +20,8 @@ func AuthRequest(root, username, code, refreshToken, grantType string) (map[stri
 	values := map[string]string{
 		"code":          code,
 		"refresh_token": refreshToken,
-		"client_id":     os.Getenv("TRAKT_ID"),
-		"client_secret": os.Getenv("TRAKT_SECRET"),
+		"client_id":     config.TraktClientId,
+		"client_secret": config.TraktClientSecret,
 		"redirect_uri":  fmt.Sprintf("%s/authorize?username=%s", root, url.PathEscape(username)),
 		"grant_type":    grantType,
 	}
@@ -177,7 +177,7 @@ func makeRequest(url string) []byte {
 
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("trakt-api-version", "2")
-	req.Header.Add("trakt-api-key", os.Getenv("TRAKT_ID"))
+	req.Header.Add("trakt-api-key", config.TraktClientId)
 
 	resp, err := client.Do(req)
 	handleErr(err)
@@ -199,7 +199,7 @@ func scrobbleRequest(action string, body []byte, accessToken string) []byte {
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", accessToken))
 	req.Header.Add("trakt-api-version", "2")
-	req.Header.Add("trakt-api-key", os.Getenv("TRAKT_ID"))
+	req.Header.Add("trakt-api-key", config.TraktClientId)
 
 	resp, _ := client.Do(req)
 	defer resp.Body.Close()

--- a/lib/trakt/main.go
+++ b/lib/trakt/main.go
@@ -119,7 +119,7 @@ func findEpisode(pr plexhooks.PlexResponse) Episode {
 
 		return showInfo[0].Episode
 	}
-	
+
 	url := fmt.Sprintf("https://api.trakt.tv/search/%s/%s?type=show", traktService, showID[1])
 
 	log.Print(fmt.Sprintf("Finding show for %s %s %s using %s", showID[1], showID[2], showID[3], traktService))

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/etherlabsio/healthcheck"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
+	"github.com/xanderstrike/goplaxt/lib/config"
 	"github.com/xanderstrike/goplaxt/lib/store"
 	"github.com/xanderstrike/goplaxt/lib/trakt"
 	"github.com/xanderstrike/plexhooks"
@@ -65,7 +66,7 @@ func authorize(w http.ResponseWriter, r *http.Request) {
 		SelfRoot:   SelfRoot(r),
 		Authorized: true,
 		URL:        url,
-		ClientID:   os.Getenv("TRAKT_ID"),
+		ClientID:   config.TraktClientId,
 	}
 	tmpl.Execute(w, data)
 }
@@ -77,7 +78,7 @@ func api(w http.ResponseWriter, r *http.Request) {
 
 	user := storage.GetUser(id)
 
-	if (user == nil) {
+	if user == nil {
 		log.Println("User not found.")
 		w.WriteHeader(http.StatusNotFound)
 		json.NewEncoder(w).Encode("user not found")
@@ -197,7 +198,7 @@ func main() {
 			SelfRoot:   SelfRoot(r),
 			Authorized: false,
 			URL:        "https://plaxt.astandke.com/api?id=generate-your-own-silly",
-			ClientID:   os.Getenv("TRAKT_ID"),
+			ClientID:   config.TraktClientId,
 		}
 		tmpl.Execute(w, data)
 	}).Methods("GET")

--- a/main_test.go
+++ b/main_test.go
@@ -108,14 +108,14 @@ type MockSuccessStore struct{}
 func (s MockSuccessStore) Ping(ctx context.Context) error { return nil }
 func (s MockSuccessStore) WriteUser(user store.User)      {}
 func (s MockSuccessStore) GetUser(id string) *store.User  { return nil }
-func (s MockSuccessStore) DeleteUser(id string) bool  { return true }
+func (s MockSuccessStore) DeleteUser(id string) bool      { return true }
 
 type MockFailStore struct{}
 
 func (s MockFailStore) Ping(ctx context.Context) error { return errors.New("OH NO") }
 func (s MockFailStore) WriteUser(user store.User)      { panic(errors.New("OH NO")) }
 func (s MockFailStore) GetUser(id string) *store.User  { panic(errors.New("OH NO")) }
-func (s MockFailStore) DeleteUser(id string) bool  { return false }
+func (s MockFailStore) DeleteUser(id string) bool      { return false }
 
 func TestHealthcheck(t *testing.T) {
 	var rr *httptest.ResponseRecorder


### PR DESCRIPTION
To fix #64, this adds the ability to load `TRAKT_ID` and `TRAKT_SECRET` from files instead of specifying them in the environment explicitly. This can be done by adding `TRAKT_ID_FILE` and `TRAKT_SECRET_FILE` env vars that contain the path to a text file which in turn contains the raw secrets as plain text.

This allows people to use [Docker secrets](https://docs.docker.com/engine/swarm/secrets/) via Docker Swarm or directly in a `docker-compose.yml` file like so:
```yml
secrets:
  trakt_client_id:
    file: ./.docker_secrets/trakt_client_id.txt
  trakt_client_secret:
    file: ./.docker_secrets/trakt_client_secret.txt

services:
  plaxt:
    image: xanderstrike/goplaxt
    container_name: plaxt
    environment:
    - TRAKT_ID_FILE=/run/secrets/trakt_client_id
    - TRAKT_SECRET_FILE=/run/secrets/trakt_client_secret
    - ALLOWED_HOSTNAMES=localhost:8000
    ports:
    - 8000:8000
    restart: unless-stopped
    volumes:
    - ./config/plaxt:/app/keystore
    secrets:
      - trakt_client_id
      - trakt_client_secret
```
